### PR TITLE
Try to mitigate occasional 500 error codes thrown by integration tests

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -71,7 +71,7 @@ try:
     SCC_RETRIES = int(os.environ.get("SCC_RETRIES"))
 except Exception:
     SCC_RETRIES = 3
-GH_RETRY_CODES = [405, 502]
+GH_RETRY_CODES = [405, 500, 502]
 
 
 def check_github_code(exception):


### PR DESCRIPTION
During the last months, the integration tests have been regularly failing
with 500 GitHub exceptions. None of these failures look reproducible. This
commit is investigating the addition of 500 to the list of error codes
to retry.